### PR TITLE
Making make_pkg.sh more compatible across nix platforms

### DIFF
--- a/make_pkg.sh
+++ b/make_pkg.sh
@@ -2,11 +2,12 @@
 
 version=$(git describe | sed -e "s/v//")
 fn=lastpass-joomla-saml-$version.zip
+statFormat="%t%t<filename>%N</filename>%n"
 
 cd plugins/authentication/lpsaml
 (echo "		<filename plugin=\"lpsaml\">lpsaml.php</filename>" ; \
  echo "		<filename>lpsaml.xml</filename>" ; \
- find . -type f ! -name lpsaml.php ! -name lpsaml.xml\* -printf "\t\t<filename>%h/%f</filename>\n") | \
+ find . -type f ! -name lpsaml.php ! -name lpsaml.xml\* -print0 | xargs -0 stat -f ${statFormat}) | \
     sed -e "s/\.\///g" > /tmp/filelist.txt
 
 filelist=$(cat /tmp/filelist.txt)

--- a/make_pkg.sh
+++ b/make_pkg.sh
@@ -2,13 +2,14 @@
 
 version=$(git describe | sed -e "s/v//")
 fn=lastpass-joomla-saml-$version.zip
-statFormat="%t%t<filename>%N</filename>%n"
 
 cd plugins/authentication/lpsaml
-(echo "		<filename plugin=\"lpsaml\">lpsaml.php</filename>" ; \
- echo "		<filename>lpsaml.xml</filename>" ; \
- find . -type f ! -name lpsaml.php ! -name lpsaml.xml\* -print0 | xargs -0 stat -f ${statFormat}) | \
-    sed -e "s/\.\///g" > /tmp/filelist.txt
+(
+  echo "		<filename plugin=\"lpsaml\">lpsaml.php</filename>" ; \
+  echo "		<filename>lpsaml.xml</filename>" ; \
+  find . -type f ! -name lpsaml.php ! -name lpsaml.xml\* -print |
+  sed -E -e "s/\.\/(.*)/		<filename>\1<\/filename>/g"
+) > /tmp/filelist.txt
 
 filelist=$(cat /tmp/filelist.txt)
 cat lpsaml.xml.tmpl | sed -e "/PLUGIN_FILES/{

--- a/make_pkg.sh
+++ b/make_pkg.sh
@@ -19,7 +19,10 @@ cat lpsaml.xml.tmpl | sed -e "/PLUGIN_FILES/{
 s/VERSION/$version/g
 " > lpsaml.xml
 
-rm $fn
+if [ -f $fn ];
+then
+  rm $fn
+fi
 zip -r $fn .
 mv $fn ../../..
 


### PR DESCRIPTION
Pull request covers the following enhancements:

1. Replaced printf in the find command with extra work in sed to be more compatible across nix platforms.
2. Added check before removing the zip file to prevent the file does not exist warning.

I've built the package from the following platforms: Mac Sierra, RHEL, Ubuntu, FreeBSD, Amazon Linux. All latest versions.

I installed each build of the plugin into Joomla 3.6.5. Then tested ability to get to the plugin config screen, and successful uninstall. All built packages worked.
